### PR TITLE
ttc-connectors-dummytwitter to 1.0.42

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,3 +10,6 @@ dependencies:
 - name: infrastructure
   repository: https://activiti.github.io/activiti-cloud-charts/
   version: 0.2.0
+- name: ttc-connectors-dummytwitter
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.42


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.42