### PR TITLE
ttc-connectors-processing to 1.0.17

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -19,6 +19,9 @@ dependencies:
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.42
+- name: ttc-connectors-processing
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.17
 - name: ttc-query-campaign
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.24


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.17