### PR TITLE
ttc-connectors-ranking to 1.0.21

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -24,7 +24,7 @@ dependencies:
   version: 1.0.17
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.20
+  version: 1.0.21
 - name: ttc-connectors-reward
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.18


### PR DESCRIPTION
Promote ttc-connectors-ranking to version 1.0.21